### PR TITLE
Specify dockerhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM makensis:latest
+FROM wheatstalk/makensis:latest
 
 RUN dpkg --add-architecture i386 \ 
     && apt-get update \


### PR DESCRIPTION
`docker pull makensis:latest` does not exists

~~I think think this should be from `wheatstalk`, but not 100% sure.~~